### PR TITLE
Deployment 2

### DIFF
--- a/server/actions/email-login.ts
+++ b/server/actions/email-login.ts
@@ -36,6 +36,7 @@ export const emailLogin = actionClient
 
       if (!existingUser.emailVerified) {
         const token = await generateEmailVerificationToken(email)
+        if ("error" in token) return { error: token.error }
         await sendVerificationEmail(token[0].email, token[0].token)
         return { success: "Confirmation email resent!" }
       }
@@ -55,7 +56,7 @@ export const emailLogin = actionClient
         } else {
           const token = await generateTwoFactorToken(existingUser.email)
           if (!token) return { error: "Failed to generate token." }
-
+          if ("error" in token) return { error: token.error }
           await sendTwoFactorTokenByEmail(token[0].email, token[0].token)
           return { twoFactor: "Two-factor code was sent to your inbox. Please check your email." }
         }

--- a/server/actions/tokens.ts
+++ b/server/actions/tokens.ts
@@ -40,7 +40,14 @@ export const getVerificationTokenByEmail = async (email: string) => {
  * @returns {Promise<object>} - A promise that resolves to the newly generated token object.
  * On failure: { error: string }
  */
-export const generateEmailVerificationToken = async (email: string) => {
+export const generateEmailVerificationToken = async (email: string): Promise<{
+  id: string;
+  email: string;
+  token: string;
+  expires: Date;
+}[] | {
+  error: string;
+}> => {
   try {
     const existingToken = await getVerificationTokenByEmail(email)
 
@@ -123,7 +130,14 @@ export const getTwoFactorTokenByEmail = async (email: string) => {
  * @param {string} email - The email address of the user for whom the 2FA token is generated.
  * @returns {Promise<object|null>} - A promise that resolves to the generated 2FA token object or null if an error occurs.
 */
-export const generateTwoFactorToken = async (email: string) => {
+export const generateTwoFactorToken = async (email: string): Promise<{
+  id: string;
+  email: string;
+  token: string;
+  expires: Date;
+}[] | {
+  error: string;
+} | null> => {
   try {
     const existingToken = await getTwoFactorTokenByEmail(email)
     if (existingToken) {
@@ -135,16 +149,15 @@ export const generateTwoFactorToken = async (email: string) => {
     })
     if (!existingUser) return { error: "User not found" }
 
-    const token = await db.insert(twoFactorTokens).values({
+    const twoFactorToken = await db.insert(twoFactorTokens).values({
       email,
       token: crypto.randomInt(100_000, 1_000_000).toString(), // generate 6-digit code
       expires: new Date(new Date().getTime() + 3600 * 1000), // set token to expire in 1 hour
     }).returning()
 
-    return token
-
+    return twoFactorToken
   } catch (error) {
-    return null
+    return { error: "Failed to generate two factor token." }
   }
 }
 


### PR DESCRIPTION
…e because expression of type '0' can't be used to index type '{ id: string; email: string; token: string; expires: Date; }[] | { error: string; }'.